### PR TITLE
Fix build

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -347,14 +347,6 @@ func (c *Controller) getAndUpdateDriverState(app *v1beta2.SparkApplication) erro
 			} else {
 				app.Status.AppState.ErrorMessage = "driver container status missing"
 			}
-			// Fetch container ExitCode/Reason if Pod Failed.
-			if pod.Status.Phase == apiv1.PodFailed {
-				if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].State.Terminated != nil {
-					currentDriverState.err = fmt.Errorf("driver pod failed with ExitCode: %d, Reason: %s", pod.Status.ContainerStatuses[0].State.Terminated.ExitCode, pod.Status.ContainerStatuses[0].State.Terminated.Reason)
-				} else {
-					currentDriverState.err = fmt.Errorf("driver container status missing.")
-				}
-			}
 		}
 	}
 

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -1403,7 +1403,7 @@ func TestSyncSparkApplication_ExecutingState(t *testing.T) {
 			}
 		}
 
-    // Verify application metrics.
+		// Verify application metrics.
 		assert.Equal(t, test.expectedAppMetrics.runningMetricCount, ctrl.metrics.sparkAppRunningCount.Value(map[string]string{}))
 		assert.Equal(t, test.expectedAppMetrics.successMetricCount, fetchCounterValue(ctrl.metrics.sparkAppSuccessCount, map[string]string{}))
 		assert.Equal(t, test.expectedAppMetrics.submitMetricCount, fetchCounterValue(ctrl.metrics.sparkAppSubmitCount, map[string]string{}))


### PR DESCRIPTION
Code that has been removed in this PR was rewritten in master and is now duplicate (338:349 has same code) and breaking the build. The v1beta2 merge possibly caused this issue.

Minor fix with formatting

Build was failing with 
```
pkg/controller/sparkapplication/controller.go:351:7: undefined: pod
pkg/controller/sparkapplication/controller.go:352:12: undefined: pod
pkg/controller/sparkapplication/controller.go:353:6: undefined: currentDriverState
pkg/controller/sparkapplication/controller.go:353:93: undefined: pod
pkg/controller/sparkapplication/controller.go:355:6: undefined: currentDriverState
```

Build passes after this change. 