### PR TITLE
Put tasks that get resource quota error in pending 

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
@@ -55,6 +55,12 @@ func SetSparkApplicationDefaults(app *SparkApplication) {
 			app.Spec.RestartPolicy.OnSubmissionFailureRetryInterval = new(int64)
 			*app.Spec.RestartPolicy.OnSubmissionFailureRetryInterval = 5
 		}
+
+		if app.Spec.RestartPolicy.OnSubmissionFailureRetries == nil {
+			app.Spec.RestartPolicy.OnSubmissionFailureRetries = new(int32)
+			*app.Spec.RestartPolicy.OnSubmissionFailureRetries = 14
+		}
+
 	}
 
 	setDriverSpecDefaults(&app.Spec.Driver)

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -455,14 +455,14 @@ func shouldRetry(app *v1beta2.SparkApplication) bool {
 		}
 	case v1beta2.PendingSubmissionState:
 		var interval int64 = 257
-		if app.Spec.Mode != v1beta2.ClusterMode && hasRetryIntervalPassed(&interval, app.Status.SubmissionAttempts, app.CreationTimestamp) && app.Status.SubmissionAttempts < 14 {
+		if app.Spec.Mode != v1beta2.ClusterMode && hasRetryIntervalPassed(&interval, app.Status.SubmissionAttempts, app.CreationTimestamp) && app.Status.SubmissionAttempts <= 14 {
 			return true
 		}
 	case v1beta2.FailedSubmissionState:
 		// We retry only if the RestartPolicy is Always. The Submission Job already retries upto the OnSubmissionFailureRetries specified.
 		if app.Spec.RestartPolicy.Type == v1beta2.Always {
 			return true
-		} else if app.Spec.RestartPolicy.Type == v1beta2.OnFailure && app.Status.SubmissionAttempts < 14 {
+		} else if app.Spec.RestartPolicy.Type == v1beta2.OnFailure && app.Status.SubmissionAttempts <= 14 {
 
 			return true
 		}

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -719,7 +719,7 @@ func (c *Controller) submitSparkApplication(app *v1beta2.SparkApplication) *v1be
 	}
 
 	if err != nil {
-		if strings.Contains(err.Error(), "exceeded quota") && app.Spec.Mode == v1beta2.ClientMode {
+		if strings.Contains(err.Error(), "exceeded quota") && app.Spec.Mode == v1beta2.ClientMode && app.Status.SubmissionAttempts < 14 {
 			app.Status = v1beta2.SparkApplicationStatus{
 				AppState: v1beta2.ApplicationState{
 					State:        v1beta2.PendingSubmissionState,

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -462,7 +462,7 @@ func shouldRetry(app *v1beta2.SparkApplication) bool {
 		// We retry only if the RestartPolicy is Always. The Submission Job already retries upto the OnSubmissionFailureRetries specified.
 		if app.Spec.RestartPolicy.Type == v1beta2.Always {
 			return true
-		} else if app.Spec.RestartPolicy.Type == v1beta2.OnFailure && app.Status.SubmissionAttempts <= 14 {
+		} else if app.Spec.RestartPolicy.Type == v1beta2.OnFailure && app.Spec.Mode != v1beta2.ClusterMode && app.Status.SubmissionAttempts <= 14 {
 
 			return true
 		}

--- a/pkg/controller/sparkapplication/controller_test.go
+++ b/pkg/controller/sparkapplication/controller_test.go
@@ -485,6 +485,7 @@ func TestValidateDetectsNodeSelectorFailsAppAndPodLevel(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+//change this test back to true, as of now retries are based on onFailureRetries
 func TestShouldRetry(t *testing.T) {
 	type testcase struct {
 		app         *v1beta2.SparkApplication
@@ -622,7 +623,7 @@ func TestShouldRetry(t *testing.T) {
 					},
 				},
 			},
-			shouldRetry: false,
+			shouldRetry: true,
 		},
 		{
 			app: &v1beta2.SparkApplication{


### PR DESCRIPTION
Before this change there is an expoential retry for failures regarding resource quota, they are failed and then the spark application is resubmitted so the flyte ui just shows task as failed. It is requested that the task not fail and retry all 14 submissions using the same entry. This now done by keeping the spark application in pending submission until all 14 retries are done so on the flyte ui it is seen as still running.

https://jira.lyft.net/browse/DATAHELP-4360
https://jira.lyft.net/browse/DATAHELP-4388

Before and After on flyte UI using functional test
before: https://flyte-staging.lyft.net/console/projects/flytefunctionaltests/domains/development/executions/vejslkh4vp
after:  https://flyte-staging.lyft.net/console/projects/flytefunctionaltests/domains/development/executions/t7gaw9zu5i

Screenshots from running on sonata-staging-- 
Run #13
<img width="1334" alt="Screen Shot 2021-05-05 at 2 52 18 PM" src="https://user-images.githubusercontent.com/55162494/117193997-8eb56000-adb1-11eb-9f0b-0e6857b34e61.png">
After 14 Runs
<img width="1333" alt="Screen Shot 2021-05-05 at 2 51 47 PM" src="https://user-images.githubusercontent.com/55162494/117194186-c8866680-adb1-11eb-89ea-3119d3a87706.png">


