### PR TITLE
Remove deploy option from spark conf

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/defaults.go
@@ -16,29 +16,14 @@ limitations under the License.
 
 package v1beta2
 
-import (
-	"strings"
-)
-
 // SetSparkApplicationDefaults sets default values for certain fields of a SparkApplication.
 func SetSparkApplicationDefaults(app *SparkApplication) {
 	if app == nil {
 		return
 	}
 
-	var deployMode DeployMode
-	for key, value := range app.Spec.SparkConf {
-		if strings.HasPrefix(key, "spark.submit.deployMode") {
-			deployMode = DeployMode(value)
-		}
-	}
-
 	if app.Spec.Mode == "" {
-		if deployMode != "" {
-			app.Spec.Mode = deployMode
-		} else {
-			app.Spec.Mode = ClientMode
-		}
+		app.Spec.Mode = ClientMode
 	}
 
 	if app.Spec.RestartPolicy.Type == "" {


### PR DESCRIPTION
Forces all spark tasks with empty mode to run in client mode, disregarding anything in spark.submit.deploy mode from spark conf. 

Related to https://jira.lyft.net/browse/DATAHELP-4404 --
Recent change in spark operator for resource quotas (https://github.com/lyft/spark-on-k8s-operator/pull/56) caused this issue because of line 547. 
The majority of workflows have an empty mode and when first submitted the defaults are added to the crd (Empty mode = client mode) but when they are rerun these defaults are not added so instead of changing the mode to client it remains empty and would otherwise enter the else. This clause is still necessary for this reason. The affected workflows failed because their mode is empty and spark.submit.deploy=cluster.